### PR TITLE
Fix IllegalStateException when tapping back from unsaved new time.

### DIFF
--- a/app/src/main/java/com/chess/clock/fragments/TimeControlFragment.java
+++ b/app/src/main/java/com/chess/clock/fragments/TimeControlFragment.java
@@ -475,7 +475,7 @@ public class TimeControlFragment extends Fragment implements StageEditorDialog.O
     /**
      * DIALOG
      */
-    private static class ExitConfirmationDialogFragment extends DialogFragment {
+    public static class ExitConfirmationDialogFragment extends DialogFragment {
 
         public static ExitConfirmationDialogFragment newInstance() {
             return new ExitConfirmationDialogFragment();


### PR DESCRIPTION
https://github.com/ChessCom/android-chessclock/issues/11

- Fragment must be a public static class to be properly recreated
from instance state.

