### PR TITLE
Enable minification on release builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,12 @@ android {
 
     buildTypes {
         release {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+        debug {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,10 @@
+-dontobfuscate
+-keepattributes SourceFile,LineNumberTable
+
+-assumenosideeffects class android.util.Log {
+    public static *** d(...);
+    public static *** v(...);
+    public static *** i(...);
+    public static *** w(...);
+    public static *** e(...);
+}

--- a/app/src/main/java/com/chess/clock/views/ClockButton.java
+++ b/app/src/main/java/com/chess/clock/views/ClockButton.java
@@ -13,12 +13,14 @@ import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
+import androidx.annotation.Keep;
 import androidx.core.content.ContextCompat;
 
 import com.chess.clock.R;
 import com.chess.clock.entities.AppTheme;
 import com.chess.clock.entities.ClockTime;
 
+@Keep
 public class ClockButton extends FrameLayout {
 
     private final TextView timeTv;
@@ -122,6 +124,7 @@ public class ClockButton extends FrameLayout {
         IDLE, LOCKED, RUNNING, FINISHED
     }
 
+    @Keep
     public interface ClockClickListener {
         void onClickClock();
 


### PR DESCRIPTION
Add minification to bring down the size of the app down from 4.7MB to 3.0MB. 
No obfuscation, because it's open source app :smile: .

Set minifyEnabled on debug for easier testing.