### PR TITLE
Update to AGP 7.4.0, SDK 33, and Appcompat 1.6.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
     namespace 'com.chess.clock'
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 32
+        targetSdkVersion 33
         versionCode 26
         versionName "1.2.0"
     }
@@ -35,7 +35,7 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'androidx.appcompat:appcompat:1.6.0'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'com.google.android.material:material:1.7.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:7.4.0'
     }
 }
 


### PR DESCRIPTION
Not really needed until Google Play requires it later this year, but was updating my fork so thought I would open a PR. 🤷

Seems to be no compatibility issues with this migration.